### PR TITLE
Show icon over mob that triggered dodge

### DIFF
--- a/SunderNP.lua
+++ b/SunderNP.lua
@@ -10,9 +10,11 @@
 ------------------------------------------------
 SunderNPDB = SunderNPDB or {}
 
+
 local SunderNP_Defaults = {
-  overpowerEnabled = false,  -- Overpower is on by default
+  overpowerEnabled = true,  -- Overpower is on by default
 }
+
 
 local function SunderNP_Initialize()
   for k, v in pairs(SunderNP_Defaults) do
@@ -21,6 +23,7 @@ local function SunderNP_Initialize()
     end
   end
 end
+
 
 ------------------------------------------------
 -- 1) Slash Command Handler
@@ -31,8 +34,10 @@ local function SunderNP_SlashCommand(msg)
     msg = ""
   end
 
+
   -- Convert to lowercase
   msg = string.lower(msg)
+
 
   if msg == "opon" then
     SunderNPDB.overpowerEnabled = true
@@ -50,70 +55,104 @@ local function SunderNP_SlashCommand(msg)
   end
 end
 
+
 ------------------------------------------------
 -- 2) Register an Event for Initialization
 ------------------------------------------------
 local SunderNPFrame = CreateFrame("Frame", "SunderNP_MainFrame")
 SunderNPFrame:RegisterEvent("VARIABLES_LOADED")
+SunderNPFrame:RegisterEvent("PLAYER_LOGIN")
 SunderNPFrame:SetScript("OnEvent", function()
   if event == "VARIABLES_LOADED" then
     SunderNP_Initialize()
     DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[SunderNP]|r loaded. Type '/sundernp help' for options.")
+  elseif event == "PLAYER_LOGIN" then
+    local _, playerGUID = UnitExists("player")
+    SunderNPDB.playerGUID = playerGUID
   end
 end)
+
 
 -- Create slash commands
 SLASH_SUNDERNP1 = "/sundernp"
 SLASH_SUNDERNP2 = "/snp"
 SlashCmdList["SUNDERNP"] = SunderNP_SlashCommand
 
+
 ------------------------------------------------
 -- 3) Overpower Logic (4s window + 5s cooldown)
 ------------------------------------------------
 local OverpowerFrame = CreateFrame("Frame", "SunderNP_OverpowerFrame", UIParent)
 
+
 -- Overpower state
 local overpowerActive = false
 local overpowerEndTime = 0
 
+
 local overpowerOnCooldown = false
 local overpowerCdEndTime  = 0
-local overpowerGUID = nil
+
+
 local function IsOverpowerActive()
   return overpowerActive and (GetTime() < overpowerEndTime)
 end
+
 
 local function IsOverpowerOnCooldown()
   return overpowerOnCooldown and (GetTime() < overpowerCdEndTime)
 end
 
+
 local function IsOverpowerUsable()
   return IsOverpowerActive() and not IsOverpowerOnCooldown()
 end
 
+
+local castevent = {}
+
 -- Listen for events that cause Overpower
 OverpowerFrame:RegisterEvent("COMBAT_TEXT_UPDATE")           -- "SPELL_ACTIVE", Overpower
-OverpowerFrame:RegisterEvent("UNIT_COMBAT")                  --  Parse "UNIT_COMBAT" for DODGE event
+OverpowerFrame:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")  -- "dodges"
 OverpowerFrame:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")   -- "Your Overpower..."
+OverpowerFrame:RegisterEvent("UNIT_CASTEVENT")               -- SuperWoW cast events
+OverpowerFrame:RegisterEvent("UNIT_COMBAT")                  -- Hack attributing 0 target whirlwinds
+
 
 OverpowerFrame:SetScript("OnEvent", function()
   local msg = arg1 or ""
+
 
   if event == "COMBAT_TEXT_UPDATE" then
     if arg1 == "SPELL_ACTIVE" and arg2 == "Overpower" then
       overpowerActive = true
       overpowerEndTime = GetTime() + 4
+    end
 
+  elseif event == "CHAT_MSG_COMBAT_SELF_MISSES" then
+    if string.find(msg, "dodges") then
+      castevent.overpowerGUID = castevent.targetGUID
+      if overpowerActive then
+        overpowerEndTime = GetTime() + 4
+      else
+        overpowerActive = true
+        overpowerEndTime = GetTime() + 4
+      end
     end
-  elseif (event == "UNIT_COMBAT") and arg2 == "DODGE" then
-    overpowerGUID = arg1
-    if overpowerActive then
-      overpowerEndTime = GetTime() + 4
-    else
-      overpowerActive = true
-      overpowerEndTime = GetTime() + 4
-    end
+
   elseif event == "CHAT_MSG_SPELL_SELF_DAMAGE" then
+    if string.find(arg1, "dodged") then
+      castevent.overpowerGUID = castevent.targetGUID
+      if string.find(arg1, "Whirlwind") then
+        castevent.whirlwind = true
+      end
+      if overpowerActive then
+        overpowerEndTime = GetTime() + 4
+      else
+        overpowerActive = true
+        overpowerEndTime = GetTime() + 4
+      end
+   end
     if string.find(msg, "^Your Overpower") then
       -- Used Overpower => 5s cooldown
       overpowerOnCooldown = true
@@ -121,29 +160,47 @@ OverpowerFrame:SetScript("OnEvent", function()
 
       if overpowerActive then
         overpowerActive = false
-        overpowerGUID = nil  -- Reset overpower target
+        castevent.overpowerGUID = nil -- Overpower used, reset
       end
+    end
+
+  elseif event == "UNIT_CASTEVENT" then
+    if arg1 == SunderNPDB.playerGUID then
+      local action, _, _, _, _ = SpellInfo(arg4)
+      castevent.action = action
+      castevent.targetGUID = arg2
+    end
+
+  elseif event == "UNIT_COMBAT" then
+    if castevent.whirlwind and arg2 == "DODGE" and castevent.action == "Whirlwind" then
+      castevent.overpowerGUID = arg1
+      castevent.whirlwind = false
     end
   end
 end)
 
+
 OverpowerFrame:SetScript("OnUpdate", function()
   local now = GetTime()
 
+
   if overpowerActive and now >= overpowerEndTime then
-    overpowerGUID = nil -- Overpower expired, reset
     overpowerActive = false
+    castevent.overpowerGUID = nil -- overpower expired, reset
   end
+
 
   if overpowerOnCooldown and now >= overpowerCdEndTime then
     overpowerOnCooldown = false
   end
 end)
 
+
 ------------------------------------------------
 -- 4) Sunder Tracking
 ------------------------------------------------
 local SunderArmorTexture = "Interface\\Icons\\Ability_Warrior_Sunder"
+
 
 local function GetSunderStacks(unit)
   for i = 1, 16 do
@@ -156,26 +213,32 @@ local function GetSunderStacks(unit)
   return 0
 end
 
+
 ------------------------------------------------
 -- 5) pfUI Nameplate Hook
 ------------------------------------------------
 local OverpowerIconTexture = "Interface\\Icons\\Ability_MeleeDamage"
 
+
 local function HookPfuiNameplates()
   if not pfUI or not pfUI.nameplates then return end
+
 
   local oldOnCreate = pfUI.nameplates.OnCreate
   pfUI.nameplates.OnCreate = function(frame)
     oldOnCreate(frame)
 
+
     local plate = frame.nameplate
     if not plate or not plate.health then return end
+
 
     -- Sunder text
     local sunderText = plate.health:CreateFontString(nil, "OVERLAY")
     sunderText:SetFont("Fonts\\FRIZQT__.TTF", 25, "OUTLINE")
     sunderText:SetPoint("LEFT", plate.health, "RIGHT", 15, 0)
     plate.sunderText = sunderText
+
 
     -- Overpower icon
     local overpowerIcon = plate.health:CreateTexture(nil, "OVERLAY")
@@ -186,6 +249,7 @@ local function HookPfuiNameplates()
     overpowerIcon:Hide()
     plate.overpowerIcon = overpowerIcon
 
+
     -- Overpower timer text
     local overpowerTimer = plate.health:CreateFontString(nil, "OVERLAY")
     overpowerTimer:SetFont("Fonts\\FRIZQT__.TTF", 16, "OUTLINE")
@@ -195,12 +259,14 @@ local function HookPfuiNameplates()
     plate.overpowerTimer = overpowerTimer
   end
 
+
   local oldOnDataChanged = pfUI.nameplates.OnDataChanged
   pfUI.nameplates.OnDataChanged = function(self, plate)
     oldOnDataChanged(self, plate)
     if not plate or not plate.sunderText or not plate.overpowerIcon or not plate.overpowerTimer then
       return
     end
+
 
     -- Sunder
     local guid = plate.parent:GetName(1)
@@ -226,13 +292,15 @@ local function HookPfuiNameplates()
       plate.sunderText:SetText("")
     end
 
+
     -- Overpower: only if user has it enabled in SunderNPDB
     if SunderNPDB.overpowerEnabled then
       -- Only show for current target
-      if overpowerGUID ~= nil and UnitIsUnit(guid, overpowerGUID) then
+      if castevent.overpowerGUID ~= nil and guid and UnitIsUnit(guid, castevent.overpowerGUID) then
         if IsOverpowerActive() then
           plate.overpowerIcon:Show()
           plate.overpowerTimer:Show()
+
 
           if IsOverpowerOnCooldown() then
             local cdLeft = math.floor(overpowerCdEndTime - GetTime() + 0.5)
@@ -264,15 +332,18 @@ local function HookPfuiNameplates()
   end
 end
 
+
 ------------------------------------------------
 -- 6) Default Blizzard Nameplates
 ------------------------------------------------
 local nameplateCache = {}
 
+
 local function CreatePlateElements(frame)
   local sunderText = frame:CreateFontString(nil, "OVERLAY")
   sunderText:SetFont("Fonts\\FRIZQT__.TTF", 25, "OUTLINE")
   sunderText:SetPoint("RIGHT", frame, "RIGHT", 15, 0)
+
 
   local overpowerIcon = frame:CreateTexture(nil, "OVERLAY")
   overpowerIcon:SetTexture(OverpowerIconTexture)
@@ -281,11 +352,13 @@ local function CreatePlateElements(frame)
   overpowerIcon:SetPoint("TOP", frame, "TOP", 0, 60)
   overpowerIcon:Hide()
 
+
   local overpowerTimer = frame:CreateFontString(nil, "OVERLAY")
   overpowerTimer:SetFont("Fonts\\FRIZQT__.TTF", 16, "OUTLINE")
   overpowerTimer:SetPoint("CENTER", overpowerIcon, "CENTER", 0, 0)
   overpowerTimer:SetText("")
   overpowerTimer:Hide()
+
 
   nameplateCache[frame] = {
     sunderText     = sunderText,
@@ -293,6 +366,7 @@ local function CreatePlateElements(frame)
     overpowerTimer = overpowerTimer,
   }
 end
+
 
 local function UpdateDefaultNameplates()
   local frames = { WorldFrame:GetChildren() }
@@ -308,6 +382,7 @@ local function UpdateDefaultNameplates()
         local overpowerIcon  = cache.overpowerIcon
         local overpowerTimer = cache.overpowerTimer
 
+
         -- Usually, current target's nameplate has alpha=1
         if frame:GetAlpha() == 1 and UnitExists("target") then
           local stacks = GetSunderStacks("target")
@@ -322,10 +397,12 @@ local function UpdateDefaultNameplates()
             sunderText:SetText("")
           end
 
+
           if SunderNPDB.overpowerEnabled then
             if IsOverpowerActive() then
               overpowerIcon:Show()
               overpowerTimer:Show()
+
 
               if IsOverpowerOnCooldown() then
                 local cdLeft = math.floor(overpowerCdEndTime - GetTime() + 0.5)
@@ -361,6 +438,7 @@ local function UpdateDefaultNameplates()
   end
 end
 
+
 local function HookDefaultNameplates()
   local updater = CreateFrame("Frame", "SunderNP_DefaultFrame")
   updater.tick = 0
@@ -371,6 +449,7 @@ local function HookDefaultNameplates()
   end)
 end
 
+
 ------------------------------------------------
 -- 7) Decide Which Hook
 ------------------------------------------------
@@ -379,3 +458,4 @@ if pfUI and pfUI.nameplates then
 else
   HookDefaultNameplates()
 end
+


### PR DESCRIPTION
With pfUI we can match the GUID of the nameplate with the `UNIT_COMBAT` event for a dodge on that mob, so we can show only the icon on the mob that triggered it (in the case of whirlwind)

Not sure how to do this with standard blizz plates